### PR TITLE
fix: align entity annotation name with FontStringEntity context

### DIFF
--- a/src/main/java/net/onelitefeather/vulpes/api/model/font/FontStringEntity.java
+++ b/src/main/java/net/onelitefeather/vulpes/api/model/font/FontStringEntity.java
@@ -12,7 +12,7 @@ import net.onelitefeather.vulpes.api.model.FontEntity;
 import java.util.Objects;
 import java.util.UUID;
 
-@Entity(name = "font_lore")
+@Entity(name = "font_string")
 public final class FontStringEntity implements Comparable<FontStringEntity> {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)


### PR DESCRIPTION
## Proposed changes

The table used to store `FontStringEntity` objects doesn't reflect the correct context. Currently, it's linked to `font_lore`, which is not accurate. This pull request corrects the table name to properly reflect its purpose.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)